### PR TITLE
Corrected bug in existing dateByAdding_: methods

### DIFF
--- a/NSDate-Utilities.h
+++ b/NSDate-Utilities.h
@@ -26,6 +26,7 @@
 
 // Comparing dates
 - (BOOL) isEqualToDateIgnoringTime: (NSDate *) aDate;
+- (BOOL) isEqualToDateIgnoringSeconds:(NSDate *)aDate;
 - (BOOL) isToday;
 - (BOOL) isTomorrow;
 - (BOOL) isYesterday;
@@ -41,12 +42,14 @@
 - (BOOL) isLaterThanDate: (NSDate *) aDate;
 
 // Adjusting dates
-- (NSDate *) dateByAddingDays: (NSUInteger) dDays;
+- (NSDate *) dateByAddingDays: (NSInteger) dDays;
 - (NSDate *) dateBySubtractingDays: (NSUInteger) dDays;
-- (NSDate *) dateByAddingHours: (NSUInteger) dHours;
+- (NSDate *) dateByAddingHours: (NSInteger) dHours;
 - (NSDate *) dateBySubtractingHours: (NSUInteger) dHours;
-- (NSDate *) dateByAddingMinutes: (NSUInteger) dMinutes;
+- (NSDate *) dateByAddingMinutes: (NSInteger) dMinutes;
 - (NSDate *) dateBySubtractingMinutes: (NSUInteger) dMinutes;
+- (NSDate *) dateByAddingSeconds: (NSInteger) dSeconds;
+- (NSDate *) dateBySubtractingSeconds: (NSUInteger) dSeconds;
 - (NSDate *) dateAtStartOfDay;
 
 // Retrieving intervals

--- a/NSDate-Utilities.m
+++ b/NSDate-Utilities.m
@@ -82,6 +82,17 @@
 			([components1 day] == [components2 day]));
 }
 
+- (BOOL) isEqualToDateIgnoringSeconds:(NSDate *)aDate
+{
+    NSDateComponents *components1 = [CURRENT_CALENDAR components:DATE_COMPONENTS fromDate:self];
+    NSDateComponents *components2 = [CURRENT_CALENDAR components:DATE_COMPONENTS fromDate:aDate];
+	return (([components1 year] == [components2 year]) &&
+			([components1 month] == [components2 month]) && 
+			([components1 day] == [components2 day]) &&
+            ([components1 hour] == [components2 hour]) &&
+            ([components1 minute] == [components2 minute]));
+}
+
 - (BOOL) isToday
 {
 	return [self isEqualToDateIgnoringTime:[NSDate date]];
@@ -170,7 +181,7 @@
 
 #pragma mark Adjusting Dates
 
-- (NSDate *) dateByAddingDays: (NSUInteger) dDays
+- (NSDate *) dateByAddingDays: (NSInteger) dDays
 {
 	NSTimeInterval aTimeInterval = [self timeIntervalSinceReferenceDate] + D_DAY * dDays;
 	NSDate *newDate = [NSDate dateWithTimeIntervalSinceReferenceDate:aTimeInterval];
@@ -182,7 +193,7 @@
 	return [self dateByAddingDays: (dDays * -1)];
 }
 
-- (NSDate *) dateByAddingHours: (NSUInteger) dHours
+- (NSDate *) dateByAddingHours: (NSInteger) dHours
 {
 	NSTimeInterval aTimeInterval = [self timeIntervalSinceReferenceDate] + D_HOUR * dHours;
 	NSDate *newDate = [NSDate dateWithTimeIntervalSinceReferenceDate:aTimeInterval];
@@ -194,7 +205,7 @@
 	return [self dateByAddingHours: (dHours * -1)];
 }
 
-- (NSDate *) dateByAddingMinutes: (NSUInteger) dMinutes
+- (NSDate *) dateByAddingMinutes: (NSInteger) dMinutes
 {
 	NSTimeInterval aTimeInterval = [self timeIntervalSinceReferenceDate] + D_MINUTE * dMinutes;
 	NSDate *newDate = [NSDate dateWithTimeIntervalSinceReferenceDate:aTimeInterval];
@@ -204,6 +215,18 @@
 - (NSDate *) dateBySubtractingMinutes: (NSUInteger) dMinutes
 {
 	return [self dateByAddingMinutes: (dMinutes * -1)];
+}
+
+- (NSDate *) dateByAddingSeconds: (NSInteger) dSeconds
+{
+    NSTimeInterval aTimeInterval = [self timeIntervalSinceReferenceDate] + dSeconds;
+    NSDate *newDate = [NSDate dateWithTimeIntervalSinceReferenceDate:aTimeInterval];
+    return newDate;
+}
+
+- (NSDate *) dateBySubtractingSeconds:(NSUInteger)dSeconds
+{
+    return [self dateByAddingSeconds: (dSeconds * -1)];
 }
 
 - (NSDate *) dateAtStartOfDay

--- a/Test Bed/main.m
+++ b/Test Bed/main.m
@@ -66,6 +66,29 @@
 		  [[NSDate date] weekday],
 		  [[NSDate date] nthWeekday],
 		  [[NSDate date] year]);
+    
+    NSDate *addSubTestDate = [NSDate date];
+    NSLog(@"Date for testing time addition and subtraction methods is: %@", addSubTestDate);
+    NSLog(@"One second later: %@", [addSubTestDate dateByAddingSeconds:1]);
+    NSLog(@"One second earlier: %@", [addSubTestDate dateBySubtractingSeconds:1]);
+    NSLog(@"One minute later: %@", [addSubTestDate dateByAddingMinutes:1]);
+    NSLog(@"One minute earlier: %@", [addSubTestDate dateBySubtractingMinutes:1]);
+    NSLog(@"One hour later: %@", [addSubTestDate dateByAddingHours:1]);
+    NSLog(@"One hour earlier: %@", [addSubTestDate dateBySubtractingHours:1]);
+    
+    NSDate *secondsTestDate = [NSDate date];
+    NSUInteger secondsTestSeconds = [secondsTestDate seconds];
+    NSLog(@"Date for testing isEqualToDateIgnoringSeconds: method is: %@", secondsTestDate);
+    NSLog(@"60 seconds from test date is the same time to the minute? (NO) %@", 
+          [secondsTestDate isEqualToDateIgnoringSeconds: [secondsTestDate dateByAddingSeconds:60]]  ? @"Yes" : @"No");
+    NSLog(@"%i seconds from test date is the same time to the minute? (NO) %@", 
+          D_MINUTE - secondsTestSeconds, [secondsTestDate isEqualToDateIgnoringSeconds: [secondsTestDate dateByAddingSeconds:D_MINUTE - secondsTestSeconds]] ? @"Yes" : @"No");
+    NSLog(@"%i seconds before test date is the same time to the minute? (NO) %@", 
+          secondsTestSeconds + 1, [secondsTestDate isEqualToDateIgnoringSeconds: [secondsTestDate dateBySubtractingSeconds:secondsTestSeconds + 1]] ? @"Yes" : @"No");
+    NSLog(@"%i seconds from test date is the same time to the minute? (YES) %@", 
+          D_MINUTE - secondsTestSeconds - 1, [secondsTestDate isEqualToDateIgnoringSeconds:[secondsTestDate dateByAddingSeconds:D_MINUTE - secondsTestSeconds - 1]] ? @"Yes" : @"No");
+    NSLog(@"%i seconds before test date is the same time to the minute? (YES) %@", 
+          secondsTestSeconds - 1, [secondsTestDate isEqualToDateIgnoringSeconds:[secondsTestDate dateBySubtractingSeconds:secondsTestSeconds - 1]] ? @"Yes" : @"No");
 }
 @end
 


### PR DESCRIPTION
Thanks for making this available! 

I found a small but important bug in the dateByAdding_: methods. Since each dateBySubtracting_: method calls its matching dateByAdding_: with a negative argument, the adding methods need to accept an NSInteger rather than NSUInteger argument to work properly.

I've implemented this small fix and also added some additional methods for working with seconds:
- Added isEqualToDateIgnoringSeconds: to determine whether dates are equivalent to the minute.
- Added methods for adjusting a date by adding and subtracting seconds.
- Added test cases for isEqualToDateIgnoringSeconds:.

Cheers!

Derek
