### PR TITLE
Fix 'dateBySubtractingDays:'

### DIFF
--- a/NSDate-Utilities.m
+++ b/NSDate-Utilities.m
@@ -228,37 +228,37 @@
 - (NSInteger) minutesAfterDate: (NSDate *) aDate
 {
 	NSTimeInterval ti = [self timeIntervalSinceDate:aDate];
-	return (NSInteger) ceil (ti / D_MINUTE);
+	return (NSInteger) (ti / D_MINUTE);
 }
 
 - (NSInteger) minutesBeforeDate: (NSDate *) aDate
 {
 	NSTimeInterval ti = [aDate timeIntervalSinceDate:self];
-	return (NSInteger) ceil (ti / D_MINUTE);
+	return (NSInteger) (ti / D_MINUTE);
 }
 
 - (NSInteger) hoursAfterDate: (NSDate *) aDate
 {
 	NSTimeInterval ti = [self timeIntervalSinceDate:aDate];
-	return (NSInteger) ceil (ti / D_HOUR);
+	return (NSInteger) (ti / D_HOUR);
 }
 
 - (NSInteger) hoursBeforeDate: (NSDate *) aDate
 {
 	NSTimeInterval ti = [aDate timeIntervalSinceDate:self];
-	return (NSInteger) ceil (ti / D_HOUR);
+	return (NSInteger) (ti / D_HOUR);
 }
 
 - (NSInteger) daysAfterDate: (NSDate *) aDate
 {
 	NSTimeInterval ti = [self timeIntervalSinceDate:aDate];
-	return (NSInteger) ceil (ti / D_DAY);
+	return (NSInteger) (ti / D_DAY);
 }
 
 - (NSInteger) daysBeforeDate: (NSDate *) aDate
 {
 	NSTimeInterval ti = [aDate timeIntervalSinceDate:self];
-	return (NSInteger) ceil (ti / D_DAY);
+	return (NSInteger) (ti / D_DAY);
 }
 
 #pragma mark Decomposing Dates


### PR DESCRIPTION
'dateByAddingDays:' message to self won't work, because it needs an NSUInteger whereas (dDays \* -1) will result to a negative number.

Same is presumably true for 'dateBySubtractingHours:' and 'dateBySubtractingMinutes:' also, not tested though.
