### PR TITLE
Bugfix:In isSameMonthAsDate: NSMonthCalendarUnit should be extracted as well.

### DIFF
--- a/NSDate-Utilities.m
+++ b/NSDate-Utilities.m
@@ -131,8 +131,8 @@
 
 - (BOOL) isSameMonthAsDate: (NSDate *) aDate
 {
-	NSDateComponents *components1 = [CURRENT_CALENDAR components:NSYearCalendarUnit fromDate:self];
-	NSDateComponents *components2 = [CURRENT_CALENDAR components:NSYearCalendarUnit fromDate:aDate];
+	NSDateComponents *components1 = [CURRENT_CALENDAR components:NSYearCalendarUnit|NSMonthCalendarUnit fromDate:self];
+	NSDateComponents *components2 = [CURRENT_CALENDAR components:NSYearCalendarUnit|NSMonthCalendarUnit fromDate:aDate];
 	return ((components1.month == components2.month) &&
             (components1.year == components2.year));
 }


### PR DESCRIPTION
A clean fix of this bug.
