### PR TITLE
isSameMonthAsDate fix

### DIFF
--- a/NSDate-Utilities.m
+++ b/NSDate-Utilities.m
@@ -131,8 +131,8 @@
 
 - (BOOL) isSameMonthAsDate: (NSDate *) aDate
 {
-	NSDateComponents *components1 = [CURRENT_CALENDAR components:NSYearCalendarUnit fromDate:self];
-	NSDateComponents *components2 = [CURRENT_CALENDAR components:NSYearCalendarUnit fromDate:aDate];
+	NSDateComponents *components1 = [CURRENT_CALENDAR components:NSYearCalendarUnit|NSMonthCalendarUnit fromDate:self];
+	NSDateComponents *components2 = [CURRENT_CALENDAR components:NSYearCalendarUnit|NSMonthCalendarUnit fromDate:aDate];
 	return ((components1.month == components2.month) &&
             (components1.year == components2.year));
 }


### PR DESCRIPTION
Hello,

I fixed the issue with comparing two dates based on month and date only (isSameMonthAsDate). There was [CURRENT_CALENDAR components:NSYearCalendarUnit... but it should be [CURRENT_CALENDAR components:NSYearCalendarUnit|NSMonthCalendarUnit.

Please accept the pull request and add the patch to your master.

Thanks, 
Michal
