### PR TITLE
Adds #undef statements at end of implementation

### DIFF
--- a/NSDate-Utilities.m
+++ b/NSDate-Utilities.m
@@ -372,3 +372,6 @@
 	return components.year;
 }
 @end
+
+#undef CURRENT_CALENDAR
+#undef DATE_COMPONENTS


### PR DESCRIPTION
I've added `#undef` statements at the end of the implementation file so developers using the library can re-use these `#define` macro identifiers. 

A better solution than using the `#define` statements here might be `static const` variables, but that's a matter of style. I can do that instead and update the pull request if you like. 
