### PR TITLE
ADDed NSCalendar static singleton

### DIFF
--- a/NSDate-Utilities.h
+++ b/NSDate-Utilities.h
@@ -14,6 +14,8 @@
 
 @interface NSDate (Utilities)
 
++(NSCalendar *)currentCalendar;
+
 // Relative dates from the current date
 + (NSDate *) dateTomorrow;
 + (NSDate *) dateYesterday;

--- a/NSDate-Utilities.m
+++ b/NSDate-Utilities.m
@@ -13,11 +13,23 @@
 #import "NSDate-Utilities.h"
 
 #define DATE_COMPONENTS (NSYearCalendarUnit| NSMonthCalendarUnit | NSDayCalendarUnit | NSWeekCalendarUnit |  NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit | NSWeekdayCalendarUnit | NSWeekdayOrdinalCalendarUnit)
-#define CURRENT_CALENDAR [NSCalendar currentCalendar]
+#define CURRENT_CALENDAR [NSDate currentCalendar]
 
 @implementation NSDate (Utilities)
 
 #pragma mark Relative Dates
+
++(NSCalendar *)currentCalendar {
+    
+    static dispatch_once_t pred;
+    static __strong NSCalendar *shared = nil;
+    
+    dispatch_once(&pred, ^{
+        shared = [NSCalendar autoupdatingCurrentCalendar];
+        
+    });
+    return shared;
+}
 
 + (NSDate *) dateWithDaysFromNow: (NSInteger) days
 {


### PR DESCRIPTION
Very often in date operations, the performance bottleneck is creating NSCalendar object (surprising, but yes - clearly visible when profiling). I have added static currentCalendar method as autoupdating calendar and refer CURRENT_CALENDAR constant to it.
