### PR TITLE
Fixed nearestHour to be relative to self - not [NSDate date]

### DIFF
--- a/NSDate+Utilities.m
+++ b/NSDate+Utilities.m
@@ -439,7 +439,7 @@ static const unsigned componentFlags = (NSYearCalendarUnit| NSMonthCalendarUnit 
 
 - (NSInteger) nearestHour
 {
-	NSTimeInterval aTimeInterval = [[NSDate date] timeIntervalSinceReferenceDate] + D_MINUTE * 30;
+	NSTimeInterval aTimeInterval = [self timeIntervalSinceReferenceDate] + D_MINUTE * 30;
 	NSDate *newDate = [NSDate dateWithTimeIntervalSinceReferenceDate:aTimeInterval];
 	NSDateComponents *components = [[NSDate currentCalendar] components:NSHourCalendarUnit fromDate:newDate];
 	return components.hour;


### PR DESCRIPTION
Fixed ```nearestHour``` to be relative to ```self``` and not ```[NSDate date]```.
As it's a decomposition, and an instance method, it should be ```self```, right?

Or am I getting this the wrong way?