### PR TITLE
fixed distanceInDays for close dates

### DIFF
--- a/NSDate+Utilities.m
+++ b/NSDate+Utilities.m
@@ -430,9 +430,16 @@ static const unsigned componentFlags = (NSYearCalendarUnit| NSMonthCalendarUnit 
 // I have not yet thoroughly tested this
 - (NSInteger)distanceInDaysToDate:(NSDate *)anotherDate
 {
-    NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-    NSDateComponents *components = [gregorianCalendar components:NSDayCalendarUnit fromDate:self toDate:anotherDate options:0];
-    return components.day;
+    NSCalendar *calendar = [NSDate currentCalendar];
+    
+    NSDate *fromDate;
+    NSDate *toDate;
+    [calendar rangeOfUnit:NSDayCalendarUnit startDate:&fromDate interval:NULL forDate:self];
+    [calendar rangeOfUnit:NSDayCalendarUnit startDate:&toDate interval:NULL forDate:anotherDate];
+    
+    NSDateComponents *difference = [calendar components:NSDayCalendarUnit fromDate:fromDate toDate:toDate options:0];
+    
+    return difference.day;
 }
 
 #pragma mark - Decomposing Dates


### PR DESCRIPTION
Previous approach wont work for close dates , for example:

distance between Aug, 20, 11:00 and Aug, 19, 14:30  was returning 0 days , but should return 1 day.